### PR TITLE
Update serverspec dependency

### DIFF
--- a/vagrant-serverspec.gemspec
+++ b/vagrant-serverspec.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'serverspec', '~> 0.12.0'
+  gem.add_dependency 'serverspec', '~> 1.0'
 
   gem.add_development_dependency 'bundler', '~> 1.3'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Hi, I'm a serverspec author.Thanks for very useful plugin that using serverspec.

Serverspec current version is 1.4.0 and I'm following Semantic Versioning.
Backwards-compatiability will be kept in version 1.x.x.

So please update the dependency in your gemspec.

Thanks.
