### PR TITLE
Add new options 'error_no_spec_files' to avoid error when no rspec co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Vagrant.configure('2') do |config|
   EOF
 
   config.vm.provision :serverspec do |spec|
+    # pattern for specfiles to search
     spec.pattern = '*_spec.rb'
+    # disable error if no specfile was found ( usefull with dynamic specfile retrieving through another provisionner like Ansible Galaxy => specfiles can be saved into ansible role repository for example ). Default: true
+    spec.error_no_spec_files = false
+    # save result into html an report, saved into a 'rspec_html_reports' directory. Default: false
+    spec.html_output = true
   end
 end
 ```

--- a/WINDOWS_README.md
+++ b/WINDOWS_README.md
@@ -34,7 +34,13 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
 
   config.vm.provision :serverspec do |spec|
+    # pattern for specfiles to search
     spec.pattern = '*_spec.rb'
+    # disable error if no specfile was found ( usefull with dynamic specfile retrieving through another provisionner like Ansible Galaxy => specfiles can be saved into ansible role repository for example ). Default: true
+    spec.error_no_spec_files = false
+    # save result into html an report, saved into a 'rspec_html_reports' directory. Default: false
+    spec.html_output = true
+
   end
 
 end

--- a/lib/vagrant-serverspec/config.rb
+++ b/lib/vagrant-serverspec/config.rb
@@ -2,18 +2,38 @@ module VagrantPlugins
   module ServerSpec
     class Config < Vagrant.plugin('2', :config)
       attr_accessor :spec_files
+      attr_accessor :spec_pattern
+      attr_accessor :error_no_spec_files_found
+      attr_accessor :html_output_format
 
       def initialize
         super
         @spec_files = UNSET_VALUE
+        @html_output_format = UNSET_VALUE
+        @error_no_spec_files_found = UNSET_VALUE
       end
 
       def pattern=(pat)
         @spec_files = Dir.glob(pat)
+        @spec_pattern = pat
+      end
+
+      def error_no_spec_files=(warn_spec)
+        if [true, false].include? warn_spec
+          @error_no_spec_files_found = warn_spec
+        end
+      end
+
+      def html_output=(html_out)
+        if [true, false].include? html_out
+          @html_output_format = html_out
+        end
       end
 
       def finalize!
         @spec_files = [] if @spec_files == UNSET_VALUE
+        @html_output_format = false if @html_output_format == UNSET_VALUE
+        @error_no_spec_files_found = true if @error_no_spec_files_found == UNSET_VALUE
       end
 
       def validate(machine)
@@ -28,7 +48,9 @@ module VagrantPlugins
           errors << I18n.t('vagrant.config.serverspec.missing_spec_files', files: missing_files.join(', '))
         end
 
-        { 'serverspec provisioner' => errors }
+        if @error_no_spec_files_found
+          { 'serverspec provisioner' => errors }
+        end
       end
     end
   end

--- a/lib/vagrant-serverspec/error.rb
+++ b/lib/vagrant-serverspec/error.rb
@@ -3,5 +3,11 @@ module Vagrant
     class ServerSpecFailed < VagrantError
       error_key(:serverspec_failed)
     end
+    class ServerSpecFailedHtml < VagrantError
+      error_key(:serverspec_failed_html)
+    end
+    class ServerSpecFilesNotFound < VagrantError
+      error_key(:serverspec_filesnotfound)
+    end
   end
 end

--- a/lib/vagrant-serverspec/version.rb
+++ b/lib/vagrant-serverspec/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ServerSpec
-    VERSION = '1.2'
+    VERSION = '1.3'
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,3 +11,9 @@ en:
       serverspec_failed: |-
         ServerSpec failed to complete successfully. Any error output should be
         visible above. Please fix these errors and try again.
+      serverspec_failed_html: |-
+        ServerSpec failed to complete successfully. Any error output should be
+        visible above. Please fix these errors and try again. Please look into 'rspec_html_reports'
+        directory to see errors into 'overview.html' file
+      serverspec_filesnotfound: |-
+        ServerSpec failed to find any spec files.

--- a/vagrant-serverspec.gemspec
+++ b/vagrant-serverspec.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   #add onlly dependencies for winrm without nokogiri
   gem.add_runtime_dependency 'winrm', '~> 2.1', '>= 2.1'
   gem.add_runtime_dependency 'os', '~> 0.9.6'
+  gem.add_runtime_dependency 'rspec_html_formatter', '~> 0.3', '>= 0.3.1'
   
   gem.add_development_dependency 'bundler', '~> 1.6', '>= 1.6.2'
   gem.add_development_dependency 'rake', '~> 10.3', '>= 10.3.2'


### PR DESCRIPTION
…nf files was found ( usefull for dynamic files retrieving like ansible-galaxy call which can download roles with its serverspec conf files ), and 'html_output' to dump result into an pretty html report with 'rspec_html_formatter' gem usage