### PR TITLE
Fix vagrant-serverspec dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant'
+  gem 'vagrant', git: 'git://github.com/mitchellh/vagrant', tag: 'v2.2.6'
 end
 
 gemspec

--- a/vagrant-serverspec.gemspec
+++ b/vagrant-serverspec.gemspec
@@ -18,11 +18,12 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'serverspec', '~> 2.30', '>= 2.30'
   
-  #add onlly dependencies for winrm without nokogiri
+  #add only dependencies for winrm without nokogiri
   gem.add_runtime_dependency 'winrm', '~> 2.1', '>= 2.1'
   gem.add_runtime_dependency 'os', '~> 0.9.6'
   gem.add_runtime_dependency 'rspec_html_formatter', '~> 0.3', '>= 0.3.1'
+  gem.add_runtime_dependency 'activesupport', '~> 5.2.3', '>= 5.2'
   
-  gem.add_development_dependency 'bundler', '~> 1.6', '>= 1.6.2'
+  gem.add_development_dependency 'bundler', '~> 1.17.3', '>= 1.17'
   gem.add_development_dependency 'rake', '~> 10.3', '>= 10.3.2'
 end


### PR DESCRIPTION
For building against vagrant 2.2.6 on MacOS Mojave

After this patch it is possible to locally build/install using `rvm` from the repo root:
```
rvm install 2.4
source ~/.rvm/scripts/rvm
rvm use 2.4
bundle install
bundle exec gem build vagrant-serverspec.gemspec
rvm use default
vagrant plugin install ./vagrant-serverspec-1.3.gem
```
This fixes https://github.com/hashicorp/vagrant/issues/11143 and https://github.com/vvchik/vagrant-serverspec/issues/37