### PR TITLE
Add 'exclude_pattern' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Vagrant.configure('2') do |config|
   config.vm.provision :serverspec do |spec|
     # pattern for specfiles to search
     spec.pattern = '*_spec.rb'
-    # disable error if no specfile was found ( usefull with dynamic specfile retrieving through another provisionner like Ansible Galaxy => specfiles can be saved into ansible role repository for example ). Default: true
+    # pattern for specfiles to ignore, similar to rspec's --exclude-pattern option
+    spec.exclude_pattern = 'but_not_*_spec.rb'
+    # disable error if no specfile was found ( useful with dynamic specfile retrieving through another provisionner like Ansible Galaxy => specfiles can be saved into ansible role repository for example ). Default: true
     spec.error_no_spec_files = false
     # save result into html an report, saved into a 'rspec_html_reports' directory. Default: false
     spec.html_output = true

--- a/lib/vagrant-serverspec/config.rb
+++ b/lib/vagrant-serverspec/config.rb
@@ -3,6 +3,8 @@ module VagrantPlugins
     class Config < Vagrant.plugin('2', :config)
       attr_accessor :spec_files
       attr_accessor :spec_pattern
+      attr_accessor :spec_excluded_files
+      attr_accessor :spec_exclude_pattern
       attr_accessor :error_no_spec_files_found
       attr_accessor :html_output_format
       attr_accessor :junit_output_format
@@ -12,6 +14,8 @@ module VagrantPlugins
       def initialize
         super
         @spec_files = UNSET_VALUE
+        @spec_excluded_files = UNSET_VALUE
+        @spec_exclude_pattern = UNSET_VALUE
         @html_output_format = UNSET_VALUE
         @error_no_spec_files_found = UNSET_VALUE
         @junit_output_format = UNSET_VALUE
@@ -21,6 +25,11 @@ module VagrantPlugins
       def pattern=(pat)
         @spec_files = Dir.glob(pat)
         @spec_pattern = pat
+      end
+
+      def exclude_pattern=(pat)
+        @spec_excluded_files = Dir.glob(pat)
+        @spec_exclude_pattern = pat
       end
 
       def error_no_spec_files=(warn_spec)
@@ -49,6 +58,9 @@ module VagrantPlugins
 
       def finalize!
         @spec_files = [] if @spec_files == UNSET_VALUE
+        @spec_exclude_pattern = '' if @spec_exclude_pattern == UNSET_VALUE
+        @spec_excluded_files = [] if @spec_excluded_files == UNSET_VALUE
+        @spec_files = @spec_files - @spec_excluded_files
         @html_output_format = false if @html_output_format == UNSET_VALUE
         @error_no_spec_files_found = true if @error_no_spec_files_found == UNSET_VALUE
         @junit_output_format = false if @junit_output_format == UNSET_VALUE

--- a/lib/vagrant-serverspec/provisioner.rb
+++ b/lib/vagrant-serverspec/provisioner.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
         super
         @spec_files = config.spec_files
         @spec_pattern = config.spec_pattern
+        @spec_excluded_files = config.spec_excluded_files
+        @spec_exclude_pattern = config.spec_exclude_pattern
         @error_no_spec_files_found = config.error_no_spec_files_found
       end
 
@@ -69,6 +71,8 @@ module VagrantPlugins
         RSpec.clear_examples
 
         @spec_files = Dir.glob(@spec_pattern)
+        @spec_excluded_files = Dir.glob(@spec_exclude_pattern)
+        @spec_files = @spec_files - @spec_excluded_files
         raise Vagrant::Errors::ServerSpecFilesNotFound if @spec_files.length == 0 and @error_no_spec_files_found
 
         RSpec.configure do |rconfig|

--- a/test/ubuntu/Vagrantfile
+++ b/test/ubuntu/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :serverspec do |spec|
     spec.pattern = '*_spec.rb'
+    spec.exclude_pattern = 'exclude_*_spec.rb'
     #Specinfra.configuration.sudo_password = 'vagrant'
   end
 end

--- a/test/ubuntu/exclude_this_spec.rb
+++ b/test/ubuntu/exclude_this_spec.rb
@@ -1,0 +1,6 @@
+context 'excluded spec file' do
+  it 'should not run' do
+    raise
+  end
+end
+


### PR DESCRIPTION
Add `exclude_pattern` option that allows to specify a pattern of spec files to ignore. Files matching this pattern will be removed from the list of files matching the `pattern` option.
This allows to mimic rspec's `--exclude-pattern` behaviour in your Vagrantfile.