### PR TITLE
fix: SSH Proxy command with Docker is only used when the host VM is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,24 @@
-### v 1.5.1 Mar 02, 2020 
+
+### v 1.5.3 (unreleased)
+* fix: SSH Proxy command with Docker is only used when the host VM is enabled
+
+### v 1.5.2 Oct 02, 2020
+* Add 'exclude_pattern' option
+
+### v 1.5.1 Mar 02, 2020
 * Security, update rake build dependency version to 12.3.3
 
-### v 1.5.0 Nov 25, 2019 
-* Add a new junit formatter 
+### v 1.5.0 Nov 25, 2019
+* Add a new junit formatter
 
 ### v 1.4.0 Nov 1, 2019 (not released)
 * Fix vagrant-serverspec dependencies to work with Vagrant 2.2.6
 
 ### v 1.3.0 Sep 24, 2017
-* Add new options 'error_no_spec_files' to avoid error when no rspec conf files was found 
+* Add new options 'error_no_spec_files' to avoid error when no rspec conf files was found
 
 ### v 1.2.0 Mar 27, 2017
-* Provide compatibility with vagrant 1.9.2 
+* Provide compatibility with vagrant 1.9.2
 * Updated .gemspec to the recommended winrm version 2.x
 * Updated WinRM::Connection instead of WinRM::WebService
 * Updated `WINDOWS_README.md`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You may want to override standard settings; a file named `spec_helper.rb` is usu
 # set :disable_sudo, true
 
 # Set environment variables
-# set :env, :LANG => 'C', :LC_MESSAGES => 'C' 
+# set :env, :LANG => 'C', :LC_MESSAGES => 'C'
 
 # Set PATH
 # set :path, '/sbin:/usr/local/sbin:$PATH'
@@ -90,8 +90,16 @@ describe port(22) do
 end
 ```
 
-##Testing Docker Containers on OSX
-On OSX the Vagrant docker provider runs a Boot2Docker VM, then launches your docker container on that VM. Vagrant does SSH Proxying to send the commands through that VM and have them reach the Docker Container. Vagrant serverspec handles this the same way by getting the container host VM infromation and proxying the commands to the machine through an SSH Proxy. This functionality was introduced in this [PR](https://github.com/vvchik/vagrant-serverspec/pull/17) 
+## Docker Provider
+
+When using the [Docker provider](https://www.vagrantup.com/docs/providers/docker), Vagrant allows to either use the local Docker Engine
+or to spin up an [Host VM](https://www.vagrantup.com/docs/providers/docker/basics#host-vm) to host the Docker Engine.
+
+Vagrant serverspec handles both cases, in particular the Host VM by getting its informations and proxying the commands to the container through an SSH Proxy.
+This functionality was introduced in this [PR](https://github.com/vvchik/vagrant-serverspec/pull/17).
+
+The SSH Proxy is used when the attribute [`force_host_vm`](https://www.vagrantup.com/docs/providers/docker/configuration#force_host_vm) is set to true
+(auto-detected by Vagrant by default, or defined in your `Vagrantfile`).
 
 ## Additional informations
 
@@ -136,8 +144,8 @@ example:
 
 ## Authors
 
-Original Idea [Jeremy Voorhis][jvoorhis] (<jvoorhis@gmail.com>).  
-Current version author and maintainer [Vladimir Babchynskyy][vvchik] (<vvchik@gmail.com>)  
+Original Idea [Jeremy Voorhis][jvoorhis] (<jvoorhis@gmail.com>).
+Current version author and maintainer [Vladimir Babchynskyy][vvchik] (<vvchik@gmail.com>)
 and a growing community of [contributors][contributors].
 
 ## License

--- a/lib/vagrant-serverspec/provisioner.rb
+++ b/lib/vagrant-serverspec/provisioner.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
           host = machine.ssh_info[:host]
           options = Net::SSH::Config.for(host)
 
-          options[:proxy]         = setup_provider_proxy if use_jump_provider?
+          options[:proxy]         = setup_provider_proxy if use_proxy?
           options[:user]          = machine.ssh_info[:username]
           options[:port]          = machine.ssh_info[:port]
           options[:keys]          = machine.ssh_info[:private_key_path]
@@ -124,21 +124,9 @@ module VagrantPlugins
         Net::SSH::Proxy::Command.new("ssh #{proxy_options} -i #{key_path} -p #{port} #{username}@#{host} nc %h %p")
       end
 
-      def use_jump_provider?
-        jump_providers = [
-          {
-           name:      "DockerProvider",
-           platforms: ["mac"]
-          }
-        ]
-        current_provider_class = machine.provider.class.name.to_s
-
-        jump_providers.any? do |jump_provider|
-          if current_provider_class.include? jump_provider[:name]
-            jump_provider[:platforms].any? do |platform|
-              OS.send("#{platform}?")
-            end
-          end
+      def use_proxy?
+        if machine.provider.class.name.to_s. == 'DockerProvider'
+          return machine.provider.config.force_host_vm
         end
       end
     end

--- a/lib/vagrant-serverspec/version.rb
+++ b/lib/vagrant-serverspec/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ServerSpec
-    VERSION = '1.5.2'
+    VERSION = '1.5.3'
   end
 end


### PR DESCRIPTION
Hello @vvchik , thanks for your work on this plugin!

This PR allows the plugin to be used when using Vagrant with the Docker provider and no VM implied, but the Docker Engine directly.

My use case is https://github.com/jenkins-infra/jenkins-infra: I want to allow the Vagrant VM used for Puppet's manifest validation to be run without requiring Virtualbox but only a Docker Engine.

When doing so, the provisioning with the serverspec provider fails with an error related to an empty host/port in the method `use_jump_provider` because there are no intermediate host VM: I'm using a direct container with SSH server in the container.

So here is a proposed changed, that use the attribute [`force_host_vm`](https://www.vagrantup.com/docs/providers/docker/configuration#force_host_vm) which value is set to `false` by default on almost all platforms: https://github.com/hashicorp/vagrant/pull/8437.


